### PR TITLE
Fix testcase description

### DIFF
--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -188,9 +188,9 @@ Generate an SPDX document with minimal information, describing two files `SPDXRe
 and `SPDXRef-fileB` (name: `./fileB.c`) with minimal information each.  
 Create the following relationships:
 
-- `SPDXRef-fileA` DESCRIBED_BY `SPDXRef-Document`, comment: `comment on DESCRIBED_BY`
+- `SPDXRef-fileA` DESCRIBED_BY `SPDXRef-DOCUMENT`, comment: `comment on DESCRIBED_BY`
 - `SPDXRef-fileA` DEPENDS_ON `SPDXRef-fileB`
-- `SPDXRef-fileB` DESCRIBED_BY `SPDXRef-Document`
+- `SPDXRef-fileB` DESCRIBED_BY `SPDXRef-DOCUMENT`
 - `SPDXRef-fileB` DEPENDENCY_OF `SPDXRef-fileA`, comment: `comment on DEPENDENCY_OF`
 
 ### Task 8: `generationLicenseTest`

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -45,7 +45,7 @@ describing one package with the following information:
 
 - Package SPDX identifier: `SPDXRef-somepackage`
 - Package version: `2.2.1`
-- Package name: `./foo.bar`
+- Package name: `package name`
 - Package supplier: `Person: Jane Doe (jane.doe@example.com)`
 - Files Analyzed: `false`
 - Package checksum:

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -224,14 +224,14 @@ Add a package, described by the document, with the following information:
 Let the package contain the following two files:
 
 - File SPDX identifier: `SPDXRef-fileA`
-    - File name: `./faa.txt`
+    - File name: `./package/faa.txt`
     - File checksum:
         - algorithm: `SHA1`
         - value: `d6a770ba38583ed4bb4525bd96e50461655d2758`
     - Concluded license: `LicenseRef-1 OR LicenseRef-two`
     - License information in file: `LicenseRef-1` and `LicenseRef-two`
 - File SPDX identifier: `SPDXRef-fileB`
-    - File name: `./fbb.txt`
+    - File name: `./package/fbb.txt`
     - File checksum:
         - algorithm: `SHA1`
         - value: `d6a770ba38583ed4bb4525bd96e50461655d2758`
@@ -242,6 +242,7 @@ Add a snippet with the following information:
 
 - Snippet SPDX identifier: `SPDXRef-somesnippet`
 - Snippet from file SPDX identifier: `SPDXRef-fileB`
+- Snippet name: `snippet name`
 - Snippet byte range: `100:200`
 - Snippet concluded license: `Aladdin`
 - License information in snippet: `Aladdin` and `DL-DE-BY-2.0`

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -60,7 +60,7 @@ the following information:
 - SPDX version: `SPDX-2.3`
 - Data license: `CC0-1.0`
 - SPDX identifier: `SPDXRef-DOCUMENT`
-- Document name: `Document test document`
+- Document name: `document name`
 - SPDX document namespace: `https://some.namespace`
 - External document references:
     - ID: `DocumentRef-externaldocumentid`

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -75,7 +75,7 @@ the following information:
 - Creator comment: `creation comment`
 - Document comment: `document comment`
 - Annotation:
-    - Annotator: `Person: Document Annotator (mail@mail.com)`
+    - Annotator: `Person: Document Reviewer (mail@mail.com)`
     - Annotation date: `2022-01-01T00:00:00Z`
     - Annotation type: `REVIEW`
     - Annotation comment: `Document level annotation`

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -19,8 +19,8 @@ A document with minimal information contains the following:
 - SPDX identifier: `SPDXRef-DOCUMENT`
 - Document name: `document name`
 - SPDX document namespace: `https://some.namespace`
-- Creator: arbitrary
-- Created: arbitrary
+- Creator: `Tool: test-tool`
+- Created: `2022-01-01T00:00:00Z`
 
 An SPDX document always requires at least one SPDX element to describe. If this is not the focus of
 the test case, it refers to using files with "minimal information".
@@ -153,7 +153,7 @@ the specification. That is, the package should contain the following information
 - Annotation:
     - Annotator: `Person: Package Annotator`
     - Annotation date: `2022-01-01T00:00:00Z`
-    - Annotation type: `REVIEW`
+    - Annotation type: `OTHER`
     - Annotation comment: `Package level annotation`
 
 The package should contain a file `SPDXRef-somefile` with minimal information.

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -184,8 +184,8 @@ Add a file `SPDXRef-somefile` with minimal information.
 
 ### Task 7: `generationRelationshipTest`
 
-Generate an SPDX document with minimal information, describing two files `SPDXRef-fileA`
-and `SPDXRef-fileB` with minimal information each.  
+Generate an SPDX document with minimal information, describing two files `SPDXRef-fileA` (name: `./fileA.c`)
+and `SPDXRef-fileB` (name: `./fileB.c`) with minimal information each.  
 Create the following relationships:
 
 - `SPDXRef-fileA` DESCRIBED_BY `SPDXRef-Document`, comment: `comment on DESCRIBED_BY`

--- a/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationBaselineSbomTestCase.java
+++ b/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationBaselineSbomTestCase.java
@@ -7,6 +7,7 @@ package org.spdx.toolsjavasolver.generationtestcases;
 import java.util.List;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.model.SpdxDocument;
+import org.spdx.library.model.SpdxNoneElement;
 
 /**
  * Test case covering baseline sbom requirements.
@@ -30,6 +31,7 @@ public class GenerationBaselineSbomTestCase {
         .setVersionInfo("2.2.1")
         .setSupplier("Person: Jane Doe (jane.doe@example.com)")
         .setChecksums(List.of(sha1Checksum))
+            .setDownloadLocation(String.valueOf(new SpdxNoneElement()))
         .build();
 
     document.getDocumentDescribes().add(spdxPackage);

--- a/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationDocumentTestCase.java
+++ b/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationDocumentTestCase.java
@@ -34,7 +34,7 @@ public class GenerationDocumentTestCase {
 
     var annotation = new Annotation(modelStore, documentUri,
         modelStore.getNextId(IModelStore.IdType.Anonymous, documentUri), null, true)
-        .setAnnotator("Person: Document Commenter (mail@mail.com)")
+        .setAnnotator("Person: Document Reviewer (mail@mail.com)")
         .setAnnotationDate("2022-01-01T00:00:00Z")
         .setComment("Document level annotation")
         .setAnnotationType(AnnotationType.REVIEW);

--- a/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationLicenseTestCase.java
+++ b/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationLicenseTestCase.java
@@ -27,15 +27,15 @@ public class GenerationLicenseTestCase {
 
     var extractedLicenseInfo1 = new ExtractedLicenseInfo(modelStore, documentUri, "LicenseRef-1",
         copyManager, true);
-    extractedLicenseInfo1.setExtractedText("extracted text");
-    extractedLicenseInfo1.setName("extracted license info name");
+    extractedLicenseInfo1.setExtractedText("extracted license text");
+    extractedLicenseInfo1.setName("extracted license 1");
     extractedLicenseInfo1.setComment("extracted license info comment");
     extractedLicenseInfo1.setSeeAlso(List.of("http://see.also", "http://extracted.license"));
 
     var extractedLicenseInfo2 = new ExtractedLicenseInfo(modelStore, documentUri, "LicenseRef-two",
         copyManager, true);
     extractedLicenseInfo2.setExtractedText("extracted text");
-    extractedLicenseInfo2.setName("extracted license info name");
+    extractedLicenseInfo2.setName("extracted license 2");
     extractedLicenseInfo2.setComment("extracted license info comment");
     extractedLicenseInfo2.setSeeAlso(List.of("http://another.license"));
 

--- a/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationLicenseTestCase.java
+++ b/spdx-tools-java-solver/src/main/java/org/spdx/toolsjavasolver/generationtestcases/GenerationLicenseTestCase.java
@@ -7,6 +7,7 @@ package org.spdx.toolsjavasolver.generationtestcases;
 import java.util.List;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.model.SpdxDocument;
+import org.spdx.library.model.SpdxNoneElement;
 import org.spdx.library.model.license.ExtractedLicenseInfo;
 import org.spdx.library.model.license.LicenseInfoFactory;
 
@@ -79,6 +80,7 @@ public class GenerationLicenseTestCase {
         .setLicenseInfosFromFile(List.of(licenseRef1or2, alladinWithException))
         .setPackageVerificationCode(spdxPackageVerificationCode)
         .setFiles(List.of(fileA, fileB))
+            .setDownloadLocation(String.valueOf(new SpdxNoneElement()))
         .build();
     document.getDocumentDescribes().add(spdxPackage);
 

--- a/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationBaselineSbomTestCase.java
+++ b/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationBaselineSbomTestCase.java
@@ -7,6 +7,7 @@ package org.spdx.testbed.generationtestcases;
 import java.util.List;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.model.SpdxDocument;
+import org.spdx.library.model.SpdxNoneElement;
 import org.spdx.testbed.util.testclassification.TestName;
 
 /**
@@ -30,6 +31,7 @@ public class GenerationBaselineSbomTestCase extends GenerationTestCase {
         .setVersionInfo("2.2.1")
         .setSupplier("Person: Jane Doe (jane.doe@example.com)")
         .setChecksums(List.of(sha1Checksum))
+        .setDownloadLocation(String.valueOf(new SpdxNoneElement()))
         .build();
 
     document.getDocumentDescribes().add(spdxPackage);

--- a/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationDocumentTestCase.java
+++ b/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationDocumentTestCase.java
@@ -34,7 +34,7 @@ public class GenerationDocumentTestCase extends GenerationTestCase {
 
     var annotation = new Annotation(modelStore, documentUri,
         modelStore.getNextId(IModelStore.IdType.Anonymous, documentUri), null, true)
-        .setAnnotator("Person: Document Commenter (mail@mail.com)")
+        .setAnnotator("Person: Document Reviewer (mail@mail.com)")
         .setAnnotationDate("2022-01-01T00:00:00Z")
         .setComment("Document level annotation")
         .setAnnotationType(AnnotationType.REVIEW);

--- a/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationLicenseTestCase.java
+++ b/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationLicenseTestCase.java
@@ -27,15 +27,15 @@ public class GenerationLicenseTestCase extends GenerationTestCase {
 
     var extractedLicenseInfo1 = new ExtractedLicenseInfo(modelStore, documentUri, "LicenseRef-1",
         copyManager, true);
-    extractedLicenseInfo1.setExtractedText("extracted text");
-    extractedLicenseInfo1.setName("extracted license info name");
+    extractedLicenseInfo1.setExtractedText("extracted license text");
+    extractedLicenseInfo1.setName("extracted license 1");
     extractedLicenseInfo1.setComment("extracted license info comment");
     extractedLicenseInfo1.setSeeAlso(List.of("http://see.also", "http://extracted.license"));
 
     var extractedLicenseInfo2 = new ExtractedLicenseInfo(modelStore, documentUri, "LicenseRef-two",
         copyManager, true);
-    extractedLicenseInfo2.setExtractedText("extracted text");
-    extractedLicenseInfo2.setName("extracted license info name");
+    extractedLicenseInfo2.setExtractedText("extracted license text");
+    extractedLicenseInfo2.setName("extracted license 2");
     extractedLicenseInfo2.setComment("extracted license info comment");
     extractedLicenseInfo2.setSeeAlso(List.of("http://another.license"));
 

--- a/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationLicenseTestCase.java
+++ b/testbed/src/main/java/org/spdx/testbed/generationtestcases/GenerationLicenseTestCase.java
@@ -7,6 +7,7 @@ package org.spdx.testbed.generationtestcases;
 import java.util.List;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.model.SpdxDocument;
+import org.spdx.library.model.SpdxNoneElement;
 import org.spdx.library.model.license.ExtractedLicenseInfo;
 import org.spdx.library.model.license.LicenseInfoFactory;
 import org.spdx.testbed.util.testclassification.TestName;
@@ -83,6 +84,7 @@ public class GenerationLicenseTestCase extends GenerationTestCase {
         .setLicenseInfosFromFile(List.of(licenseRef1or2, alladinWithException))
         .setPackageVerificationCode(spdxPackageVerificationCode)
         .setFiles(List.of(fileA, fileB))
+        .setDownloadLocation(String.valueOf(new SpdxNoneElement()))
         .build();
     document.getDocumentDescribes().add(spdxPackage);
 

--- a/testbed/src/test/resources/testInput/generation/BaselineSbomTest.xml
+++ b/testbed/src/test/resources/testInput/generation/BaselineSbomTest.xml
@@ -20,5 +20,6 @@
     <name>package name</name>
     <supplier>Person: Jane Doe (jane.doe@example.com)</supplier>
     <versionInfo>2.2.1</versionInfo>
+    <downloadLocation>NONE</downloadLocation>
   </packages>
 </Document>

--- a/testbed/src/test/resources/testInput/generation/DocumentTest.xml
+++ b/testbed/src/test/resources/testInput/generation/DocumentTest.xml
@@ -23,7 +23,7 @@
   <annotations>
     <annotationDate>2022-01-01T00:00:00Z</annotationDate>
     <annotationType>REVIEW</annotationType>
-    <annotator>Person: Document Commenter (mail@mail.com)</annotator>
+    <annotator>Person: Document Reviewer (mail@mail.com)</annotator>
     <comment>Document level annotation</comment>
   </annotations>
   <documentDescribes>SPDXRef-somefile</documentDescribes>

--- a/testbed/src/test/resources/testInput/generation/LicenseTest.xml
+++ b/testbed/src/test/resources/testInput/generation/LicenseTest.xml
@@ -28,6 +28,7 @@
   <packages>
     <SPDXID>SPDXRef-somepackage</SPDXID>
     <filesAnalyzed>true</filesAnalyzed>
+    <downloadLocation>NONE</downloadLocation>
     <licenseConcluded>((LicenseRef-1 WITH u-boot-exception-2.0 OR LicenseRef-two) AND Aladdin WITH
       Classpath-exception-2.0)
     </licenseConcluded>

--- a/testbed/src/test/resources/testInput/generation/LicenseTest.xml
+++ b/testbed/src/test/resources/testInput/generation/LicenseTest.xml
@@ -11,16 +11,16 @@
   <hasExtractedLicensingInfos>
     <licenseId>LicenseRef-1</licenseId>
     <comment>extracted license info comment</comment>
-    <extractedText>extracted text</extractedText>
-    <name>extracted license info name</name>
+    <extractedText>extracted license text</extractedText>
+    <name>extracted license 1</name>
     <seeAlsos>http://see.also</seeAlsos>
     <seeAlsos>http://extracted.license</seeAlsos>
   </hasExtractedLicensingInfos>
   <hasExtractedLicensingInfos>
     <licenseId>LicenseRef-two</licenseId>
     <comment>extracted license info comment</comment>
-    <extractedText>extracted text</extractedText>
-    <name>extracted license info name</name>
+    <extractedText>extracted license text</extractedText>
+    <name>extracted license 2</name>
     <seeAlsos>http://another.license</seeAlsos>
   </hasExtractedLicensingInfos>
   <documentDescribes>SPDXRef-somepackage</documentDescribes>


### PR DESCRIPTION
I started to work on #36 and encountered some smaller issues where the description of the testcases doesn't comply with the respective tests. In most cases, I have adapted the description. 
As long as we can't exclude certain fields from the comparison (#32) we need to specify `createdby` and `creators`. 